### PR TITLE
Add Ruby 3 compatibility to v5.2.1

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,7 +9,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      super(URI(URI.escape(target)), options)
+      escaped = Paperclip::UrlGenerator.escape(target)
+      super(URI(target == Paperclip::UrlGenerator.unescape(target) ? escaped : target), options)
     end
   end
 end

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -51,7 +51,7 @@ module Paperclip
     def download_content
       options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
-      open(@target, **options)
+      URI.open(@target, options)
     end
 
     def copy_to_tempfile(src)

--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -24,7 +24,7 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
+            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, **column_options)
           end
         end
       end
@@ -51,7 +51,7 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            column("#{attachment_name}_#{column_name}", column_type, column_options)
+            column("#{attachment_name}_#{column_name}", column_type, **column_options)
           end
         end
       end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -2,6 +2,13 @@ require 'uri'
 
 module Paperclip
   class UrlGenerator
+    class << self
+      def encoder
+        @encoder ||= URI::RFC2396_Parser.new
+      end
+      delegate :escape, :unescape, to: :encoder
+    end
+
     def initialize(attachment)
       @attachment = attachment
     end
@@ -64,7 +71,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        self.class.escape(url).gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -40,7 +40,7 @@ module Paperclip
       end
 
       def mark_invalid(record, attribute, types)
-        record.errors.add attribute, :invalid, options.merge(:types => types.join(', '))
+        record.errors.add attribute, :invalid, **options.merge(:types => types.join(', '))
       end
 
       def allowed_types

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -40,7 +40,7 @@ module Paperclip
       end
 
       def mark_invalid(record, attribute, patterns)
-        record.errors.add attribute, :invalid, options.merge(:names => patterns.join(', '))
+        record.errors.add attribute, :invalid, **options.merge(:names => patterns.join(', '))
       end
 
       def allowed

--- a/lib/paperclip/validators/attachment_presence_validator.rb
+++ b/lib/paperclip/validators/attachment_presence_validator.rb
@@ -5,7 +5,7 @@ module Paperclip
     class AttachmentPresenceValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         if record.send("#{attribute}_file_name").blank?
-          record.errors.add(attribute, :blank, options)
+          record.errors.add(attribute, :blank, **options)
         end
       end
 

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -27,7 +27,7 @@ module Paperclip
             unless value.send(CHECKS[option], option_value)
               error_message_key = options[:in] ? :in_between : option
               [ attr_name, base_attr_name ].each do |error_attr_name|
-                record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
+                record.errors.add(error_attr_name, error_message_key, **filtered_options(value).merge(
                   :min => min_value_in_human_size(record),
                   :max => max_value_in_human_size(record),
                   :count => human_size(option_value)

--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -24,7 +24,7 @@ module ModelReconstruction
 
   def reset_table table_name, &block
     block ||= lambda { |table| true }
-    ActiveRecord::Base.connection.create_table :dummies, {force: true}, &block
+    ActiveRecord::Base.connection.create_table :dummies, force: true, &block
   end
 
   def modify_table table_name, &block


### PR DESCRIPTION
Starting from Paperclip 5.2.1, introduce Ruby 3 compatibility changes on two fields:
1) kwarg arguments
2) URI changes

Steps taken:
1) Went through https://github.com/thoughtbot/paperclip/compare/master...kreeti:kt-paperclip:master and checked every commit for Ruby 3 compatibility, 2 were found:
   1) Kwarg changes: https://github.com/thoughtbot/paperclip/commit/ab1016d77336a8d7b9db72eb29b6bd19af4027fc
   2) URI changes (escape and open): https://github.com/thoughtbot/paperclip/commit/f0367733ddf37141ae00517c6697cc3dd233dab9
2) Went through the changes, compared them with the last version in case there were any bugfixes to them

Only issue is: I don't manage to run all of the specs:
> 1093 examples, 385 failures

On the starting branch, there are:

> 1093 examples, 385 failures

It's not ideal, but it looks OK? 😬 

I guess we don't merge this but leave it as a separate track labeled v5.2.1-ruby3 perhaps?